### PR TITLE
- Bug Fix #include "device_pinmap.h" is in .h file

### DIFF
--- a/model/CM300Batsense.cpp
+++ b/model/CM300Batsense.cpp
@@ -20,6 +20,7 @@
 
 #include "CodalConfig.h"
 #include "CM300Batsense.h"
+#include "device_pinmap.h"
 
 using namespace codal;
 

--- a/model/CM300Batsense.h
+++ b/model/CM300Batsense.h
@@ -19,7 +19,6 @@
 
 #include "CodalConfig.h"
 #include "CM300IO.h"
-#include "device_pinmap.h"
 #include "Event.h"
 #include "Sensor.h"
 

--- a/model/CM300Joystick.cpp
+++ b/model/CM300Joystick.cpp
@@ -20,6 +20,7 @@
 
 #include "CodalConfig.h"
 #include "CM300Joystick.h"
+#include "device_pinmap.h"
 
 using namespace codal;
 

--- a/model/CM300Joystick.h
+++ b/model/CM300Joystick.h
@@ -21,7 +21,6 @@
 #include "CM300IO.h"
 #include "Event.h"
 #include "Sensor.h"
-#include "device_pinmap.h"
 
 
 namespace codal

--- a/model/CM300SAADC.cpp
+++ b/model/CM300SAADC.cpp
@@ -20,6 +20,8 @@
 
 #include "CodalConfig.h"
 #include "CM300SAADC.h"
+#include "device_pinmap.h"
+
 
 using namespace codal;
 

--- a/model/CM300SAADC.h
+++ b/model/CM300SAADC.h
@@ -19,7 +19,6 @@
 
 #include "CodalConfig.h"
 #include "CM300IO.h"
-#include "device_pinmap.h"
 #include "Event.h"
 #include "Sensor.h"
 


### PR DESCRIPTION
- Bug Fix #include "device_pinmap.h" is in .h file
- move it to .cpp file
- when make pxt serve Pin name redefinition error is occurred